### PR TITLE
Replace slide link with Twitter check-in

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@
       <div class="slides">
         <section>
 	  <div class="qrcode" id="qrcode-talk"/>
-	  <p><a href="http://hastexo.github.io/openedx2015" target="_blank"
-		id="talk">http://hastexo.github.io/openedx2015</a></p>
+	  <p><a href="https://goo.gl/y87Ht3" target="_blank"
+		id="talk">Let me know you're here!</a></p>
         </section>
         <section id="intro"
                  data-markdown="markdown/intro.md"


### PR DESCRIPTION
Here's one more suggestion you might want to use for the talk:

Instead of pointing attendees just to the slide deck, direct them to Twitter where they can let the world know they're in the talk. Also, include the link to the slides in the Twitter message.

Uses Tweet Web Intents (https://dev.twitter.com/web/tweet-button/web-intent) in combination with a URL encoder and goo.gl (to simplify the link, which in turn makes the QR code scan faster).

If you choose to pull this, it's probably best to apply to merge this into `master`, and to then drop the slide altogether from `gh-pages` (such that when someone follows the link they have received from Twitter, they land on the title slide, not on the QR code slide).
